### PR TITLE
created discriminated tuple

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,4 +28,33 @@ describe("tryTm", () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe("I'm a failure");
    });
+
+   it("Should return 'data' kind if the promise resolves", async () => {
+      const promiseFn = vi
+         .fn()
+         .mockImplementationOnce(async () =>
+            Promise.resolve({ hey: "Bedesqui" }),
+         );
+
+      const [data, error, kind] = await trytm(promiseFn());
+
+      expect(kind).toStrictEqual("data");
+      expect(data).toStrictEqual({ hey: "Bedesqui" });
+      expect(error).toBeNull();
+   });
+
+   it("Should return 'error' kind if the promise rejects", async () => {
+      const promiseFn = vi
+         .fn()
+         .mockImplementationOnce(async () =>
+            Promise.reject(new Error("I'm a failure")),
+         );
+
+      const [data, error] = await trytm(promiseFn());
+
+      expect(kind).toStrictEqual("error");
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("I'm a failure");
+   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@
 export const trytm = async <T>(promise: Promise<T>) => {
    try {
       const data = await promise;
-      return [data, null] as const;
+      return [data, null, 'data'] as const;
    } catch (error) {
-      return [null, error] as const;
+      return [null, error, 'error'] as const;
    }
 };


### PR DESCRIPTION
We can use discriminated tuples to infer T when there is an early return.

another option is to do this 

```ts
export const tryTm = async <T>(promise: Promise<T>) => {
        try {
            const data = await promise;
            return [data, null] as const;
        } catch (error) {
            return [null, error as Error] as const;
        }
    };
```