### PR TITLE
Fix: return types. But still let non-errors to be thrown

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,7 +15,7 @@ describe("tryTm", () => {
       expect(error).toBeNull();
    });
 
-   it("Should return error if the promise rejects", async () => {
+   it("Should return error if the promise rejects with an Error value", async () => {
       const promiseFn = vi
          .fn()
          .mockImplementationOnce(async () =>
@@ -27,5 +27,20 @@ describe("tryTm", () => {
       expect(data).toBeNull();
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe("I'm a failure");
+   });
+
+   it("Should throw if the promise rejects with an non-Error value", async () => {
+      expect.assertions(1);
+
+      const promiseFn = vi
+         .fn()
+         .mockImplementationOnce(async () =>
+            Promise.reject({ someNonErrorValue: "Maybe I'm not a failure" }),
+         );
+
+      await trytm(promiseFn())
+         .catch(throwable => {
+            expect(throwable).toEqual({ someNonErrorValue: "Maybe I'm not a failure" })
+         })
    });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 // blatantly stolen from fireship at https://www.youtube.com/watch?v=ITogH7lJTyE
 
-export const trytm = async <T>(promise: Promise<T>) => {
+export const trytm = async <T>(promise: Promise<T>): Promise<[T, null] | [null, Error]> => {
    try {
       const data = await promise;
-      return [data, null] as const;
-   } catch (error) {
-      return [null, error] as const;
+      return [data, null];
+   } catch (throwable) {
+      if (throwable instanceof Error) return [null, throwable]
+      
+      throw throwable
    }
 };


### PR DESCRIPTION
closes #4 
- Specify the return type as union.
- Return from catch block only if the `throwable` is instance of Error
- Allow responses to be thrown like in Remix per @adwinying's advice

Preview:
![try-preview](https://user-images.githubusercontent.com/42563517/221187603-480d4c5b-34af-493c-8e5b-3875d8412276.gif)

